### PR TITLE
Fix integer encoding / decoding on big endian systems

### DIFF
--- a/SharpIpp/Protocol/Extensions/BinaryReaderExtensions.cs
+++ b/SharpIpp/Protocol/Extensions/BinaryReaderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace SharpIpp.Protocol.Extensions
 {
@@ -6,22 +7,22 @@ namespace SharpIpp.Protocol.Extensions
     {
         public static short ReadInt16BigEndian(this BinaryReader reader)
         {
-            return Bytes.Reverse(reader.ReadInt16());
+            var value = reader.ReadInt16();
+
+            if (BitConverter.IsLittleEndian)
+                value = Bytes.Reverse(value);
+
+            return value;
         }
 
         public static int ReadInt32BigEndian(this BinaryReader reader)
         {
-            return Bytes.Reverse(reader.ReadInt32());
-        }
+            var value = reader.ReadInt32();
 
-        public static short ReadInt16BigEndianAsync( this BinaryReader reader )
-        {
-            return Bytes.Reverse( reader.ReadInt16() );
-        }
+            if (BitConverter.IsLittleEndian)
+                value = Bytes.Reverse(value);
 
-        public static int ReadInt32BigEndianAsync( this BinaryReader reader )
-        {
-            return Bytes.Reverse( reader.ReadInt32() );
+            return value;
         }
     }
 }

--- a/SharpIpp/Protocol/Extensions/BinaryWriterExtensions.cs
+++ b/SharpIpp/Protocol/Extensions/BinaryWriterExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace SharpIpp.Protocol.Extensions
 {
@@ -6,12 +7,18 @@ namespace SharpIpp.Protocol.Extensions
     {
         public static void WriteBigEndian(this BinaryWriter writer, short value)
         {
-            writer.Write(Bytes.Reverse(value));
+            if (BitConverter.IsLittleEndian)
+                value = Bytes.Reverse(value);
+
+            writer.Write(value);
         }
 
         public static void WriteBigEndian(this BinaryWriter writer, int value)
         {
-            writer.Write(Bytes.Reverse(value));
+            if (BitConverter.IsLittleEndian)
+                value = Bytes.Reverse(value);
+
+            writer.Write(value);
         }
     }
 }

--- a/SharpIpp/Protocol/Models/MediaSize.cs
+++ b/SharpIpp/Protocol/Models/MediaSize.cs
@@ -32,7 +32,7 @@ public class MediaSize
         return new MediaSize
         {
             XDimension = mapper.MapFromDic<int?>(dict, nameof(XDimension).ConvertCamelCaseToDash()),
-            YDimension = mapper.MapFromDic<int?>(dict, nameof(XDimension).ConvertCamelCaseToDash())
+            YDimension = mapper.MapFromDic<int?>(dict, nameof(YDimension).ConvertCamelCaseToDash())
         };
     }
 }


### PR DESCRIPTION
BitConverter.IsLittleEndian is an intrinsic that will return true on little endian systems and false on big endian ones, and the JIT is smart enough to generate branchless code.

Closes #4 