### PR TITLE
Add support for `WhichJobsSupported` and `{Pdf|Jpeg}KOctetsSupported`

### DIFF
--- a/SharpIpp/Mapping/Profiles/GetPrinterAttributesProfile.cs
+++ b/SharpIpp/Mapping/Profiles/GetPrinterAttributesProfile.cs
@@ -70,6 +70,8 @@ namespace SharpIpp.Mapping.Profiles
                         map.MapFromDicSetNull<IppVersion[]?>(src, PrinterAttribute.IppVersionsSupported),
                     JobImpressionsSupported = map.MapFromDic<Range?>(src, PrinterAttribute.JobImpressionsSupported),
                     JobKOctetsSupported = map.MapFromDic<Range?>(src, PrinterAttribute.JobKOctetsSupported),
+                    JpegKOctetsSupported = map.MapFromDic<Range?>(src, PrinterAttribute.JpegKOctetsSupported),
+                    PdfKOctetsSupported = map.MapFromDic<Range?>(src, PrinterAttribute.PdfKOctetsSupported),
                     JobMediaSheetsSupported = map.MapFromDic<Range?>(src, PrinterAttribute.JobMediaSheetsSupported),
                     MultipleDocumentJobsSupported =
                         map.MapFromDic<bool?>(src, PrinterAttribute.MultipleDocumentJobsSupported),
@@ -134,6 +136,7 @@ namespace SharpIpp.Mapping.Profiles
                     MediaColDefault = src.ContainsKey(PrinterAttribute.MediaColDefault) ? MediaCol.Create(src[PrinterAttribute.MediaColDefault].FromBegCollection().ToIppDictionary(), map) : null,
                     PrintColorModeDefault = map.MapFromDic<PrintColorMode?>(src, PrinterAttribute.PrintColorModeDefault),
                     PrintColorModeSupported = map.MapFromDicSetNull<PrintColorMode[]?>(src, PrinterAttribute.PrintColorModeSupported),
+                    WhichJobsSupported = map.MapFromDicSetNull<WhichJobs[]?>(src, PrinterAttribute.WhichJobsSupported),
                 } );
 
             mapper.CreateMap<GetPrinterAttributesResponse, IDictionary<string, IppAttribute[]>>( ( src, map ) =>
@@ -159,6 +162,10 @@ namespace SharpIpp.Mapping.Profiles
                         dic.Add( PrinterAttribute.JobImpressionsSupported, new IppAttribute[] { new IppAttribute( Tag.RangeOfInteger, PrinterAttribute.JobImpressionsSupported, src.JobImpressionsSupported.Value ) } );
                     if ( src.JobKOctetsSupported != null )
                         dic.Add( PrinterAttribute.JobKOctetsSupported, new IppAttribute[] { new IppAttribute( Tag.RangeOfInteger, PrinterAttribute.JobKOctetsSupported, src.JobKOctetsSupported.Value ) } );
+                    if (src.JpegKOctetsSupported != null)
+                        dic.Add(PrinterAttribute.JpegKOctetsSupported, new IppAttribute[] { new IppAttribute(Tag.RangeOfInteger, PrinterAttribute.JpegKOctetsSupported, src.JpegKOctetsSupported.Value) });
+                    if (src.PdfKOctetsSupported != null)
+                        dic.Add(PrinterAttribute.PdfKOctetsSupported, new IppAttribute[] { new IppAttribute(Tag.RangeOfInteger, PrinterAttribute.PdfKOctetsSupported, src.PdfKOctetsSupported.Value) });
                     if ( src.JobMediaSheetsSupported != null )
                         dic.Add( PrinterAttribute.JobMediaSheetsSupported, new IppAttribute[] { new IppAttribute( Tag.RangeOfInteger, PrinterAttribute.JobMediaSheetsSupported, src.JobMediaSheetsSupported.Value ) } );
                     if ( src.MultipleDocumentJobsSupported != null )
@@ -265,6 +272,8 @@ namespace SharpIpp.Mapping.Profiles
                         dic.Add(PrinterAttribute.PrintColorModeDefault, new IppAttribute[] { new IppAttribute(Tag.Keyword, PrinterAttribute.PrintColorModeDefault, map.Map<string>(src.PrintColorModeDefault.Value)) });
                     if (src.PrintColorModeSupported?.Any() ?? false)
                         dic.Add(PrinterAttribute.PrintColorModeSupported, src.PrintColorModeSupported.Select(x => new IppAttribute(Tag.Keyword, PrinterAttribute.PrintColorModeSupported, map.Map<string>(x))).ToArray());
+                    if (src.WhichJobsSupported?.Any() ?? false)
+                        dic.Add(PrinterAttribute.WhichJobsSupported, src.WhichJobsSupported.Select(x => new IppAttribute(Tag.Keyword, PrinterAttribute.WhichJobsSupported, map.Map<string>(x))).ToArray());
                     return dic;
                 } );
         }

--- a/SharpIpp/Models/GetPrinterAttributesResponse.cs
+++ b/SharpIpp/Models/GetPrinterAttributesResponse.cs
@@ -174,6 +174,16 @@ namespace SharpIpp.Models
         public Range? JobKOctetsSupported { get; set; }
 
         /// <summary>
+        ///     jpeg-k-octets-supported
+        /// </summary>
+        public Range? JpegKOctetsSupported { get; set; }
+
+        /// <summary>
+        ///     pdf-k-octets-supported
+        /// </summary>
+        public Range? PdfKOctetsSupported { get; set; }
+
+        /// <summary>
         ///     job-impressions-supported
         /// </summary>
         public Range? JobImpressionsSupported { get; set; }
@@ -248,5 +258,7 @@ namespace SharpIpp.Models
 
         public PrintColorMode? PrintColorModeDefault { get; set; }
         public PrintColorMode[]? PrintColorModeSupported { get; set; }
+
+        public WhichJobs[]? WhichJobsSupported { get; set; }
     }
 }

--- a/SharpIpp/Protocol/Models/PrinterAttribute.cs
+++ b/SharpIpp/Protocol/Models/PrinterAttribute.cs
@@ -37,6 +37,8 @@ namespace SharpIpp.Protocol.Models
         public const string MultipleOperationTimeOut = "multiple-operation-time-out";
         public const string CompressionSupported = "compression-supported";
         public const string JobKOctetsSupported = "job-k-octets-supported";
+        public const string JpegKOctetsSupported = "jpeg-k-octets-supported";
+        public const string PdfKOctetsSupported = "pdf-k-octets-supported";
         public const string JobImpressionsSupported = "job-impressions-supported";
         public const string JobMediaSheetsSupported = "job-media-sheets-supported";
         public const string PagesPerMinute = "pages-per-minute";
@@ -67,6 +69,7 @@ namespace SharpIpp.Protocol.Models
         public const string MediaColDefault = "media-col-default";
         public const string PrintColorModeDefault = "print-color-mode-default";
         public const string PrintColorModeSupported = "print-color-mode-supported";
+        public const string WhichJobsSupported = "which-jobs-supported";
 
         public static IEnumerable<string> GetAttributes(IppVersion version)
         {
@@ -84,7 +87,7 @@ namespace SharpIpp.Protocol.Models
             yield return PrinterState;
             yield return PrinterStateReasons;
             yield return PrinterStateMessage;
-            yield return IppVersionsSupported ;
+            yield return IppVersionsSupported;
             yield return OperationsSupported;
             yield return MultipleDocumentJobsSupported;
             yield return CharsetConfigured;
@@ -103,6 +106,8 @@ namespace SharpIpp.Protocol.Models
             yield return MultipleOperationTimeOut;
             yield return CompressionSupported;
             yield return JobKOctetsSupported;
+            yield return JpegKOctetsSupported;
+            yield return PdfKOctetsSupported;
             yield return JobImpressionsSupported;
             yield return JobMediaSheetsSupported;
             yield return PagesPerMinute;
@@ -133,6 +138,7 @@ namespace SharpIpp.Protocol.Models
             yield return MediaColDefault;
             yield return PrintColorModeDefault;
             yield return PrintColorModeSupported;
+            yield return WhichJobsSupported;
         }
     }
 }


### PR DESCRIPTION
Adds support for more attributes in `GetPrinterAttributes`, namely  `WhichJobsSupported` and `{Pdf|Jpeg}KOctetsSupported`